### PR TITLE
Fix REST local host string

### DIFF
--- a/apps/backend/logic/system.js
+++ b/apps/backend/logic/system.js
@@ -84,7 +84,7 @@ async function getLndConnectUrls() {
     macaroon
   });
 
-  let restLocalHost = `${constants.DEVICE_DOMAIN_NAME}:${constants.LND_REST_PORT}}`;
+  let restLocalHost = `${constants.DEVICE_DOMAIN_NAME}:${constants.LND_REST_PORT}`;
   const restLocal = encode({
     host: restLocalHost,
     cert,


### PR DESCRIPTION
The REST local host string is `domain:port}` instead of `domain:port`.
I removed the `}` character.